### PR TITLE
Header improvements to simplify use in Swift and Interface Builder

### DIFF
--- a/MultiSelectSegmentedControl.h
+++ b/MultiSelectSegmentedControl.h
@@ -13,17 +13,21 @@
 
 @class MultiSelectSegmentedControl;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol MultiSelectSegmentedControlDelegate <NSObject>
--(void)multiSelect:(MultiSelectSegmentedControl*) multiSelecSegmendedControl didChangeValue:(BOOL) value atIndex: (NSUInteger) index;
+-(void)multiSelect:(MultiSelectSegmentedControl*) multiSelectSegmentedControl didChangeValue:(BOOL) value atIndex: (NSUInteger) index;
 @end
 
 @interface MultiSelectSegmentedControl : UISegmentedControl
 
-@property (nonatomic, assign) NSIndexSet *selectedSegmentIndexes;
-@property (nonatomic, weak) id<MultiSelectSegmentedControlDelegate> delegate;
+@property (nonatomic, copy, null_resettable) NSIndexSet *selectedSegmentIndexes;
+@property (nonatomic, weak, nullable) id<MultiSelectSegmentedControlDelegate> delegate;
 @property (nonatomic, readonly) NSArray *selectedSegmentTitles;
-@property (nonatomic, assign) BOOL hideSeparatorBetweenSelectedSegments;
+@property (nonatomic, assign) IBInspectable BOOL hideSeparatorBetweenSelectedSegments;
 
 - (void)selectAllSegments:(BOOL)select; // pass NO to deselect all
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This very small change makes working with MultiSelectSegmentedControl a bit easier in Swift, and it allows configuration of the `hideSeparatorBetweenSelectedSegments` property from Interface Builder. The only changes are to the header, so it should be an inconsequential change to existing users of this library.

If this does get merged, it would be helpful to issue a new version of the pod (presumably v1.1.1) as well.