### PR TITLE
Annotate -selectedSegmentTitles as `NSArray<NSString*>*`

### DIFF
--- a/MultiSelectSegmentedControl.h
+++ b/MultiSelectSegmentedControl.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, null_resettable) NSIndexSet *selectedSegmentIndexes;
 @property (nonatomic, weak, nullable) id<MultiSelectSegmentedControlDelegate> delegate;
-@property (nonatomic, readonly) NSArray *selectedSegmentTitles;
+@property (nonatomic, readonly) NSArray<NSString*> *selectedSegmentTitles;
 @property (nonatomic, assign) IBInspectable BOOL hideSeparatorBetweenSelectedSegments;
 
 - (void)selectAllSegments:(BOOL)select; // pass NO to deselect all

--- a/MultiSelectSegmentedControl.m
+++ b/MultiSelectSegmentedControl.m
@@ -36,9 +36,9 @@
     self.selectedSegmentIndexes = select ? [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.numberOfSegments)] : [NSIndexSet indexSet];
 }
 
-- (NSArray*)selectedSegmentTitles {
-	
-	__block NSMutableArray *titleArray = [[NSMutableArray alloc] initWithCapacity:[self.selectedSegmentIndexes count]];
+- (NSArray<NSString *> *)selectedSegmentTitles
+{
+	__block NSMutableArray<NSString*> *titleArray = [[NSMutableArray alloc] initWithCapacity:[self.selectedSegmentIndexes count]];
 	
 	[self.selectedSegmentIndexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
 		//NSLog(@"segment index is selected: %d; text: %@", idx, [self titleForSegmentAtIndex:idx]);
@@ -47,7 +47,7 @@
 		
 	}];
 	
-	return [NSArray arrayWithArray:titleArray];
+	return [titleArray copy];
 	
 }
 


### PR DESCRIPTION
I failed to notice this on the last go-round. Presently, Swift imports this property as `Array<Any>`, but with this change, it will correctly import as `Array<String>`.

I also changed the return expression to a `-copy` because, according to a WWDC panel I saw, iOS 11 and macOS High Sierra's version of Foundation will employ a Copy-on-Write technique when copying collections (presumably compatibly with Swift's own CoW). And since the source `NSMutableArray` goes out of scope immediately after the `-copy`, the backing buffer won't be modified, and thus the creation of the `NSArray` doesn't require allocating another buffer.